### PR TITLE
Fix total count for models using softDelete

### DIFF
--- a/src/Builder/Contrib/MasonCollection/Container/EloquentContainer.php
+++ b/src/Builder/Contrib/MasonCollection/Container/EloquentContainer.php
@@ -151,7 +151,17 @@ class EloquentContainer implements Container
 
     public function getItems($limit, $offset)
     {
-        $total = $this->query->getQuery()->getCountForPagination();
+        /* Use query builder count for cross-DBMS compatibility */
+        $total = $this->query->count();
+        /**/
+        
+        /* versatile count for complicated queries such as union *
+        $total = \DB::select(
+            "SELECT COUNT(*) AS qty FROM (" . $this->query->toSql() . ") AS sub",
+            $this->query->getBindings()
+        )[0]->qty;
+        /**/
+        
         $pageOfItems = $this->query->skip($offset)->take($limit)->get();
 
         return [$pageOfItems, $total];


### PR DESCRIPTION
$this->query->toSql() has the softDelete criteria
$this->query->getQuery()->toSql() does not.

If we want to support complex queries with unions in them, the commented out code will work with that.  Otherwise, just to be careful with multiple potential target DBMS support, we will use the query builder count function.
