### PR TITLE
Added support of filters operator sounds, based on function SOUNDEX

### DIFF
--- a/src/Builder/Contrib/MasonCollection.php
+++ b/src/Builder/Contrib/MasonCollection.php
@@ -26,7 +26,8 @@ class MasonCollection extends Document
         // one-argument operators
         1 => [
             'eq', 'ne', 'lt', 'gt', 'lte', 'gte',
-            'starts-with', 'ends-with', 'contains', 'not-starts-with', 'not-ends-with', 'not-contains'
+            'starts-with', 'ends-with', 'contains', 'not-starts-with', 'not-ends-with', 'not-contains',
+            'sounds', 'not-sounds'
         ],
 
         // two-argument operators

--- a/src/Builder/Contrib/MasonCollection/Container/CollectionContainer.php
+++ b/src/Builder/Contrib/MasonCollection/Container/CollectionContainer.php
@@ -76,6 +76,12 @@ class CollectionContainer implements Container
                 case 'not-contains':
                     return (!preg_match("/" . preg_quote($params[0]) . "/i", $item->{$field}));
 
+                case 'sounds':
+                    return soundex($params[0]) == soundex($item->{$field});
+
+                case 'not-sounds':
+                    return soundex($params[0]) != soundex($item->{$field});
+
                 // Dual-parameter operators
 
                 case 'between':

--- a/src/Builder/Contrib/MasonCollection/Container/EloquentContainer.php
+++ b/src/Builder/Contrib/MasonCollection/Container/EloquentContainer.php
@@ -117,6 +117,14 @@ class EloquentContainer implements Container
                 });
                 break;
 
+            case 'sounds':
+                $this->query->whereRaw('SOUNDEX(' . $column .') = SOUNDEX(%s)', [$params[0]]);
+                break;
+
+            case 'not-sounds':
+                $this->query->whereRaw('SOUNDEX(' . $column .') != SOUNDEX(%s)', [$params[0]]);
+                break;
+
             // Dual-parameter operators
 
             case 'between':


### PR DESCRIPTION
It works in MySQL, should work in PostgreSQL and in SQLite  (not by default). 

Notice: SOUNDEX() in MySQL is NOT compatible with PHP implementation.